### PR TITLE
feat(docker): add local build for jekyll/GitHub page

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MY_PLATFORM="linux/arm64/v8"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# User-specific stuff:
+# for Jetbrains users.
+.idea/
+
+## jekyllのbuild, serveのargsで試行錯誤したが、
+## .sass-cacheの階層変更の方法を見つけ出せなかったため、.gitignoreで対応とする
+docs/.sass-cache/
+docs/_site/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM jekyll/jekyll:latest
+
+WORKDIR /srv/jekyll
+RUN echo 'source "https://rubygems.org"' >> Gemfile && \
+# Ruby 3.0以降包含されておらず、jekyll/jekyll:4のRuby versionが、本Docker環境構築時点で3.1.1のため
+echo 'gem "webrick"' >> Gemfile && \
+echo 'gem "jekyll-theme-cayman"' >> Gemfile && \
+echo 'gem "github-pages",  "232", group: :jekyll_plugins' >> Gemfile && \
+echo 'gem "jekyll-relative-links"' >> Gemfile && \
+bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM jekyll/jekyll:latest
 
 WORKDIR /srv/jekyll
+# Gemfileをコンテナイメージ内で用意する
+# ローカルホストマシンで活用するわけではなく、現状コンテナでのみ活用することから
+# Gemfile/lockファイル自体のGit管理とせず、Dockerfileで生成する
 RUN echo 'source "https://rubygems.org"' >> Gemfile && \
 # Ruby 3.0以降包含されておらず、jekyll/jekyll:4のRuby versionが、本Docker環境構築時点で3.1.1のため
 echo 'gem "webrick"' >> Gemfile && \
 echo 'gem "jekyll-theme-cayman"' >> Gemfile && \
 echo 'gem "github-pages",  "232", group: :jekyll_plugins' >> Gemfile && \
+# in GitHub Actions Workflow, already applied. but local cannot apply.
 echo 'gem "jekyll-relative-links"' >> Gemfile && \
 bundle install

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # ローカルでの起動方法
-https://github.com/pages-themes/cayman?tab=readme-ov-file をご確認ください
+
+1. 以下コマンドでコンテナを立ち上げます
+   * docs配下を`jekyll serve` します
+    ```shell
+    docker compose up
+    ```
+2. ブラウザで以下にアクセスします
+    * http://localhost:4000
+
+
+## できること
+* 既存ファイルの内容変更に伴うauto reload
+
+## できないこと
+
+* 新規Markdownファイルの作成に伴うルーティングのauto reload
+  * 新規Markdownファイルへのリンクを作成し、遷移してもnot foundになってしまう
+    * リンクが、新規MarkdownファイルをHTMLにconvertした結果のリンクになっていないため
+  * 解決策
+    * コンテナの立ち上げ直し

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  website:
+    build: .
+    platform: $MY_PLATFORM
+    working_dir: /srv/jekyll/docs
+    command: >
+      /bin/bash -c "
+      jekyll serve --config _config.yml,_config.local.yml --watch --baseurl /bokueki
+      "
+    volumes:
+      - $PWD/docs:/srv/jekyll/docs
+    ports:
+      - "4000:4000"

--- a/docs/_config.local.yml
+++ b/docs/_config.local.yml
@@ -1,0 +1,7 @@
+# Overwrite config for local
+theme: jekyll-theme-cayman
+plugins:
+  # in GitHub Actions Workflow, already applied. but local cannot apply.
+  - jekyll-relative-links
+sass:
+  cache: false


### PR DESCRIPTION
for improvement create some episodes in local.

# Checkpoints I want

* [ ] Can build and serve our jekyll page in your local
    * [ ] and transition other page
* [ ] Optimize this image for your platform with .env
* [ ] Auto reload when we change our docs
* [ ] (appendix) We no need GitHub access when serve our pages in docker

# I cannot implement
* Auto reload when change config, add page, change directory structures
    * We need to re-run `docker compose down/up`
       * currently, I don't know why need it, Cashing in `_site` ?

_Please feel free to comments from YOU!_